### PR TITLE
[modify] Azure OpenAIのコンテンツ管理ポリシーの記載を追加

### DIFF
--- a/docs/04_modify_prompt.md
+++ b/docs/04_modify_prompt.md
@@ -13,6 +13,7 @@
 * 指示は明確か？
 * 回答のスタイルが指定されているか？
 * フォールバックメカニズムは実装されているか？
+* [Azure OpenAIのコンテンツ管理ポリシー](https://learn.microsoft.com/ja-jp/azure/ai-services/openai/concepts/default-safety-policies)にのっとっているか？
 
 ### プロンプト例
 


### PR DESCRIPTION
This pull request includes a small documentation update to the `docs/04_modify_prompt.md` file. The change adds a new guideline to ensure compliance with Azure OpenAI's content management policy.

Documentation update:

* [`docs/04_modify_prompt.md`](diffhunk://#diff-fce55f1aa5e09e0be1d5b3b391bca19aba35a17e424a60c24affeeb63ba5465fR16): Added a guideline to check if the prompt adheres to [Azure OpenAI's content management policy](https://learn.microsoft.com/ja-jp/azure/ai-services/openai/concepts/default-safety-policies).